### PR TITLE
Add a default stylesheet to the aplus theme

### DIFF
--- a/theme/aplus/layout.html
+++ b/theme/aplus/layout.html
@@ -38,6 +38,10 @@
     <link rel="stylesheet" href="https://plus.cs.hut.fi/static/css/main.css" />
 
     {%- if style %}
+    {# This is either the stylesheet defined in theme.conf (default.css) or
+       a custom CSS file defined in the course conf.py file (variable html_style).
+       The custom stylesheet may use `@import url("default.css");` in order to
+       include the stylesheet from the theme. #}
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" data-aplus="yes" />
     {%- endif %}
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" data-aplus="yes" />

--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -1,0 +1,73 @@
+/* This Sphinx theme is designed for content that is embedded in the A+
+learning management system and thus the theme defines CSS rules for only some
+special components. Generic and body-level rules come from the A+ system. */
+
+/* -- admonitions ----------------------------------------------------------- */
+
+.admonition {
+  min-height: 42px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 1.5rem;
+  /* default colors */
+  color: #606060;
+  background-color: #e8e8e8;
+  border-color: #d7d7d7;
+}
+
+.admonition button {
+  margin-bottom: 0.5rem;
+}
+
+.admonition-title {
+  font-weight: 700;
+  margin: 0px 0px 0.5rem;
+}
+
+.admonition .last {
+  margin-bottom: 0;
+}
+
+.admonition dt {
+  font-weight: bold;
+}
+
+.admonition dl {
+  margin-bottom: 0;
+}
+
+/* Specialized admonitions use different colours */
+.admonition.success, .admonition.meta {
+  color: #3c763d;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}
+
+.admonition.info, .admonition.note, .admonition.seealso {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+.admonition.warning, .admonition.caution, .admonition.attention, .admonition.admonition-todo {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+}
+
+.admonition.danger, .admonition.error {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}
+
+.admonition.aside {
+  color: #606060;
+  background-color: #e8e8e8;
+  border-color: #d7d7d7;
+}
+

--- a/theme/aplus/theme.conf
+++ b/theme/aplus/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = basic
-stylesheet =
+stylesheet = default.css
 pygments_style = colorful
 
 [options]


### PR DESCRIPTION
Currently it supports admonition components. There are no rules that conflict with the normal A+ style. Courses may still override the CSS used in the RST compilation (to replace or extend this stylesheet).

See #5 