### PR TITLE
Update the URL of MathJax JS.

### DIFF
--- a/theme/aplus/layout.html
+++ b/theme/aplus/layout.html
@@ -33,7 +33,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/github.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
 
-    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
     <link rel="stylesheet" href="https://plus.cs.hut.fi/static/css/main.css" />
 


### PR DESCRIPTION
mathjax.org is no longer supported.
https://www.mathjax.org/cdn-shutting-down/
