### PR TITLE
Skip the difficulty class if the difficulty is not set.

### DIFF
--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -55,7 +55,8 @@ class Questionnaire(AbstractExercise):
             classes.append(u'feedback')
         else:
             category = u'questionnaire'
-            classes.append(u'difficulty-' + difficulty)
+            if difficulty:
+                classes.append(u'difficulty-' + difficulty)
 
         env = self.state.document.settings.env
         name = u"{}_{}".format(env.docname.replace(u'/', u'_'), key)

--- a/directives/submit.py
+++ b/directives/submit.py
@@ -40,7 +40,8 @@ class SubmitForm(AbstractExercise):
         classes = [u'exercise']
         if 'class' in self.options:
             classes.extend(self.options['class'])
-        classes.append(u'difficulty-' + difficulty)
+        if difficulty:
+            classes.append(u'difficulty-' + difficulty)
 
         # Add document nodes.
         args = {


### PR DESCRIPTION
If the exercise does not use any difficulty, the `difficulty` variable is None and the previous code crashes since `Nonetype` cannot be coerced to a string.