### PR TITLE
Support the Sphinx latex builder when A+ RST directives are used

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -37,13 +37,24 @@ def setup(app):
     # Add node type that can describe HTML elements and store configurations.
     app.add_node(
         aplus_nodes.html,
-        html=(aplus_nodes.visit_html, aplus_nodes.depart_html)
+        html=(aplus_nodes.visit_html, aplus_nodes.depart_html),
+        latex=(aplus_nodes.visit_ignore, aplus_nodes.depart_ignore),
+        # TODO: This html node is used by the A+ exercise directives that embed exercises into chapters.
+        # The Latex builder could insert some content about the exercise to show where it would
+        # be embedded in the HTML page instead of completely ignoring the exercise directive.
+        # There could be a configuration option to control whether the Latex builder should
+        # ignore exercises or not.
+        # Note: even though these latex visitor functions do nothing, the exercise directives
+        # nonetheless output some text to the Latex/PDF output. The text is even often duplicated
+        # multiple times. This is possibly caused by broken aplus_nodes classes that interfere
+        # with the builder output even though only the visitor functions should do that.
     )
 
     # The directive for injecting document meta data.
     app.add_node(
         aplus_nodes.aplusmeta,
-        html=(aplus_nodes.visit_ignore, aplus_nodes.depart_ignore)
+        html=(aplus_nodes.visit_ignore, aplus_nodes.depart_ignore),
+        latex=(aplus_nodes.visit_ignore, aplus_nodes.depart_ignore),
     )
     app.add_directive('aplusmeta', AplusMeta)
 

--- a/directives/annotated.py
+++ b/directives/annotated.py
@@ -11,6 +11,8 @@ from sphinx.directives.code import CodeBlock
 from sphinx.errors import SphinxError
 from operator import itemgetter
 
+import aplus_nodes
+
 annotated_section_counts = Counter()
 
 class AnnotationError(SphinxError):
@@ -328,11 +330,16 @@ def annotate(html, section_name, annotations):
 
 def setup(app):
 
-    app.add_node(annotated_node, html=(visit_annotated_node, depart_annotated_node))
+    ignore_visitors = (aplus_nodes.visit_ignore, aplus_nodes.depart_ignore)
+
+    app.add_node(annotated_node, html=(visit_annotated_node, depart_annotated_node),
+            latex=ignore_visitors)
     app.add_directive('annotated', AnnotatedSection)
 
-    app.add_node(annotation_node, html=(visit_annotation_node, depart_annotation_node))
+    app.add_node(annotation_node, html=(visit_annotation_node, depart_annotation_node),
+            latex=ignore_visitors)
     app.add_directive('annotation', Annotation)
 
-    app.add_node(altered_node, html=(visit_altered_node, depart_altered_node))
+    app.add_node(altered_node, html=(visit_altered_node, depart_altered_node),
+            latex=ignore_visitors)
     app.add_directive('altered-code-block', AlteredCodeBlock)

--- a/directives/media.py
+++ b/directives/media.py
@@ -4,6 +4,8 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.util.compat import Directive
 
+import aplus_nodes
+
 # DIRECTIVE FOR ARTICULATE STORYLINE BLOCKS: story
 
 class story_node(nodes.General, nodes.Element): pass
@@ -154,17 +156,24 @@ def depart_iframe_node(self, node):
 
 def setup(app):
 
-    app.add_node(story_node, html=(visit_story_node, depart_story_node))
+    ignore_visitors = (aplus_nodes.visit_ignore, aplus_nodes.depart_ignore)
+
+    app.add_node(story_node, html=(visit_story_node, depart_story_node),
+            latex=ignore_visitors)
     app.add_directive('story', BasicStory)
 
-    app.add_node(jsvee_node, html=(visit_jsvee_node, depart_jsvee_node))
+    app.add_node(jsvee_node, html=(visit_jsvee_node, depart_jsvee_node),
+            latex=ignore_visitors)
     app.add_directive('jsvee', JSVEE)
 
-    app.add_node(youtube_node, html=(visit_youtube_node, depart_youtube_node))
+    app.add_node(youtube_node, html=(visit_youtube_node, depart_youtube_node),
+            latex=ignore_visitors)
     app.add_directive('youtube', YouTubeVideo)
 
-    app.add_node(video_node, html=(visit_video_node, depart_video_node))
+    app.add_node(video_node, html=(visit_video_node, depart_video_node),
+            latex=ignore_visitors)
     app.add_directive('local-video', LocalVideo)
 
-    app.add_node(iframe_node, html=(visit_iframe_node, depart_iframe_node))
+    app.add_node(iframe_node, html=(visit_iframe_node, depart_iframe_node),
+            latex=ignore_visitors)
     app.add_directive('embedded-page', IFrame)

--- a/directives/repl.py
+++ b/directives/repl.py
@@ -6,6 +6,8 @@ from sphinx.util.compat import Directive
 from cgi import escape
 import re
 
+import aplus_nodes
+
 # DIRECTIVE FOR REPL SESSIONS: repl
 # this is an embarrassing mess, but it works for now. if you're thinking of making changes, rewrite instead.
 # is there some better way to go about this by using inheritance from literal_block; 
@@ -89,10 +91,14 @@ def depart_res_count_reset_node(self, node):
 
 def setup(app):
 
-    app.add_node(repl_node, html=(visit_repl_node, depart_repl_node))
+    ignore_visitors = (aplus_nodes.visit_ignore, aplus_nodes.depart_ignore)
+
+    app.add_node(repl_node, html=(visit_repl_node, depart_repl_node),
+            latex=ignore_visitors)
     app.add_directive('repl', REPLSession)
 
-    app.add_node(res_count_reset_node, html=(visit_res_count_reset_node, depart_res_count_reset_node))
+    app.add_node(res_count_reset_node, html=(visit_res_count_reset_node, depart_res_count_reset_node),
+            latex=ignore_visitors)
     app.add_directive('repl-res-count-reset', ResCountReset)
 
 

--- a/toc_config.py
+++ b/toc_config.py
@@ -16,6 +16,12 @@ def prepare(app):
 
 def write(app, exception):
     ''' Writes the table of contents level configuration. '''
+    if app.builder.name != 'html':
+        # course configuration YAML is only built with the Sphinx HTML builder
+        # because some parts of the YAML generation have only been implemented
+        # in the visit methods of the HTML builder (aplus_nodes functions
+        # visit_html and depart_html)
+        return
     if exception:
         return
 


### PR DESCRIPTION
Related issue #9 

Normally you support different builders by defining visit methods for them for each node when `setup` calls `app.add_node`. However, it was not enough with `a-plus-rst-tools` due to other problems.

`aplus_nodes.html` and `.aplusmeta` inherit `docutils.nodes.Element`, which has a constructor
that expects many keyword arguments. The classes in `aplus_nodes` used to override
the constructor in such a way that it did not accept those other arguments expected by
the base class and this caused a crash, for example, `TypeError: __init__() got an unexpected keyword argument 'dupnames'`. However, it seems that this issue does not affect the Sphinx `html` builder while it definetely affects the `latex` builder.

With the new code in the pull request, the node class constructors do not crash if they receive more keyword arguments that are intended for the superclass constructor. There is an overridden copy method as well because at least with the `latex` builder, Sphinx runs a deep copy 
of the document tree and it uses a monkey-patched copy method for the `docutils.nodes.Element` class (see `sphinx.util.nodes._new_copy` [source](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/util/nodes.py#L365)). The constructor is called like `newnode = self.__class__(self.rawsource, **self.attributes)`, which could imply that it is safer to define the `aplus_nodes` constructors with prototypes that start with the same positional parameters as the superclass's constructor.
Alternatively, perhaps the `aplus_nodes` classes should override the `copy` method, which is what I did. Without the overridden copy methods, the constructors would be called with incorrect arguments when the `latex` builder is run.

(The `tagname` variable should be defined as a class variable according to the API docs. That is a problem with `aplus_nodes.html` since the tagname actually varies, but at least the `aplusmeta` does not need to define the `tagname` at all since the default value taken from the class name is good enough.)

Some of the course configuration YAML generation has been bundled into the HTML visit methods, thus only `make html` builds the config YAML properly. It is not worthwhile to refactor the old code right now.

Exercise directives still output something to the Latex PDF even though empty visitor functions are used. The aplus_nodes classes are probably broken in that sense since only the visitor function should affect the builder output.