### PR TITLE
Fix the label font colour in Sphinx bibliographies.

### DIFF
--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -223,6 +223,12 @@ table.citation td {
     border-bottom: none;
 }
 
+table.citation .label {
+    /* Bootstrap makes labels unreadable in Sphinx bibliographies (lists of references)
+    by using white font on white background. */
+    color: #333333;
+}
+
 /* -- figures --------------------------------------------------------------- */
 
 div.figure {


### PR DESCRIPTION
Bootstrap CSS gives the label class white font colour, but
that does not work when Sphinx uses the label class in its
own labels in bibliographies. With white background, the text
becomes unreadable, so this change makes the font colour
black again.