### PR TITLE
make MathJax optional

### DIFF
--- a/theme/aplus/layout.html
+++ b/theme/aplus/layout.html
@@ -33,7 +33,9 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/github.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
 
+    {%- if theme_include_mathjax %}
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    {%- endif %}
 
     <link rel="stylesheet" href="https://plus.cs.hut.fi/static/css/main.css" />
 

--- a/theme/aplus/theme.conf
+++ b/theme/aplus/theme.conf
@@ -6,3 +6,4 @@ pygments_style = colorful
 [options]
 nosidebar = True
 use_wide_column = True
+include_mathjax = True


### PR DESCRIPTION
MathJax was included in all HTML output. Now it is still on by default
but easily disabled with a Sphinx theme option.