### PR TITLE
Module key based on dir structure

### DIFF
--- a/toc_config.py
+++ b/toc_config.py
@@ -183,7 +183,11 @@ def make_index(app, root):
         close_src = meta.get('close-time', title_date_match.group(1) if title_date_match else course_close)
         late_src = meta.get('late-time', course_late)
         module = {
-            u'key': docname.split(u'/')[0],
+            # modules01/index -> modules01
+            # modules/01/index -> modules_01
+            # modules/01/n/index -> modules_01_n
+            # ...
+            u'key': docname if u'/' not in docname else u'_'.join(docname.split(u'/')[:-1]),
             u'status': status,
             u'name': title,
             u'children': [],


### PR DESCRIPTION
Hello!

Problem:
If your module hierarchy is:
- index
- modules/01/index
- modules/02/index
- modules/nn/index

all module **_keys_** in the generated yaml file will be "modules". This of course conflicts with everything, and A+ happily merges all the material into a single round which has the configuration of the last-defined module. In other words, current implementation only works for modules that are placed in the root in single directories, not in directories inside directories.

This PR fixes this problem.

Current behaviour:
* module key comes from the root dir name of that module

New behaviour:
* module key comes from the whole dir hierarchy of that module, all occurences of "/" are replaced with "_"
