### PR TITLE
Hacky traky fix: late deadlines

### DIFF
--- a/directives/meta.py
+++ b/directives/meta.py
@@ -21,7 +21,7 @@ class Meta(Directive):
     option_spec = {
         'open-time': directives.unchanged,
         'close-time': directives.unchanged,
-        'late-close': directives.unchanged,
+        'late-time': directives.unchanged,
         'late-penalty': directives.unchanged,
     }
 

--- a/toc_config.py
+++ b/toc_config.py
@@ -116,7 +116,7 @@ def write(app, exception):
         meta = first_meta(doc)
         open_src = meta.get('open-time', course_open)
         close_src = meta.get('close-time', title_date_match.group(1) if title_date_match else course_close)
-        late_close_src = meta.get('late-close', course_close)
+        late_close_src = meta.get('late-time', course_close)
         late_penalty_src = meta.get('late-penalty', 0.5)
         module = {
             'key': docname.split('/')[0],


### PR DESCRIPTION
Rename the late-close option to late-time because that is used in the master branch (and in the source code of the course).