### PR TITLE
Fix image URLs in exercise descriptions for A+

### DIFF
--- a/lib/html_tools.py
+++ b/lib/html_tools.py
@@ -31,25 +31,27 @@ def rewrite_file_links(path, root, chapter_dirs, static_host):
         static_host,
         chapter_dirs,
         u'data-aplus-chapter="yes" ',
+        u'data-aplus-path="/static/{course}" ',
     )
     _write_file(path, content)
 
 
 def rewrite_links(content, path, root, link_elements, other_elements,
-                    static_host, chapter_dirs, chapter_append):
+                    static_host, chapter_dirs, chapter_append, yaml_append):
     dir_name = os.path.dirname(path)
     q1 = re.compile(r'^(\w+:|#)')
     q2 = re.compile(r'^(' + '|'.join(chapter_dirs) + r')(/|\\)')
     for tag,attr in link_elements:
         content = rewrite_elements(content, tag, attr, dir_name, root,
-                                    q1, static_host, q2, chapter_append)
+                                    q1, static_host, q2, chapter_append, yaml_append)
     for tag,attr in other_elements:
         content = rewrite_elements(content, tag, attr, dir_name, root,
-                                    q1, static_host, None, None)
+                                    q1, static_host, None, None, yaml_append)
     return content
 
 
-def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append):
+def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append,
+                    yaml_append):
     out = ""
     p = re.compile(
         r'<' + tag + r'\s+[^<>]*'
@@ -83,6 +85,21 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
                     j = m.start('val')
                     out += content[i:j] + static_host + my_path.replace('\\','/')
                     i = m.end('val')
+            elif path.endswith('yaml') and yaml_append and val.startswith('../') \
+                    and not out.endswith(yaml_append):
+                # Sphinx sets URLs to local files as relative URLs that work in
+                # the local filesystem (e.g., ../_images/myimage.png).
+                # The A+ frontend converts the URLs correctly when they are in
+                # the chapter content. (The URL must be converted to an absolute
+                # URL that refers to the MOOC grader course static files.)
+                # However, the conversion does not work for URLs in exercise
+                # descriptions because unlike for chapters, the service URL of
+                # an exercise does not refer to the course static files.
+                # Therefore, we add the attribute data-aplus-path="/static/{course}"
+                # that A+ frontend uses to set the correct URL path.
+                # Unfortunately, we must hardcode the MOOC grader static URL
+                # (/static) here.
+                out += yaml_append
 
     out += content[i:]
     return out


### PR DESCRIPTION
The A+ frontend must convert relative URLs in the course materials
to absolute since the URLs must refer to the backend server,
not to A+, when the material is viewed through A+.
<img> source URLs in exercise descriptions were not handled
correctly in the A+ frontend. They worked in chapter contents but
not in exercise descriptions because the service URLs for chapters
are based on the MOOC grader static URL while the exercise service
URLs are different than the static URL.

This fix adds data-aplus-path attribute to the img and similar
elements that link to a local file. This is done only in exercises,
not in the chapter contents. The attribute allows A+ to set
the image URL correctly.