### PR TITLE
Add the course head URLs setting to the index.yaml

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -37,6 +37,7 @@ def setup(app):
     app.add_config_value('skip_language_inconsistencies', False, 'html')
     app.add_config_value('allow_assistant_viewing', True, 'html')
     app.add_config_value('allow_assistant_grading', False, 'html')
+    app.add_config_value('course_head_urls', None, 'html')
 
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)

--- a/toc_config.py
+++ b/toc_config.py
@@ -249,6 +249,12 @@ def make_index(app, root):
         index[u'start'] = parse_date(course_open)
     if course_close:
         index[u'end'] = parse_date(course_close)
+    head_urls = app.config.course_head_urls
+    if head_urls is not None:
+        # If the value is None, it is not set to the index.yaml nor aplus-json at all.
+        # If the value is an empty list, it is still part of the index.yaml
+        # and could be used to override a previous truthy value.
+        index[u'head_urls'] = head_urls
 
     return index
 


### PR DESCRIPTION
The head URLs value is defined in the Sphinx conf.py with the
option course_head_urls (list of strings). If it is not set,
the course index.yaml or the exported JSON of the mooc-grader
do not define the head_urls key and the A+ course import does not
overwrite a potentially existing manually set value.