### PR TITLE
Fix relative URL issues in exercise descriptions

### DIFF
--- a/lib/html_tools.py
+++ b/lib/html_tools.py
@@ -38,20 +38,20 @@ def rewrite_file_links(path, root, chapter_dirs, static_host):
 
 def rewrite_links(content, path, root, link_elements, other_elements,
                     static_host, chapter_dirs, chapter_append, yaml_append):
-    dir_name = os.path.dirname(path)
     q1 = re.compile(r'^(\w+:|#)')
     q2 = re.compile(r'^(' + '|'.join(chapter_dirs) + r')(/|\\)')
     for tag,attr in link_elements:
-        content = rewrite_elements(content, tag, attr, dir_name, root,
+        content = rewrite_elements(content, tag, attr, path, root,
                                     q1, static_host, q2, chapter_append, yaml_append)
     for tag,attr in other_elements:
-        content = rewrite_elements(content, tag, attr, dir_name, root,
+        content = rewrite_elements(content, tag, attr, path, root,
                                     q1, static_host, None, None, yaml_append)
     return content
 
 
 def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append,
                     yaml_append):
+    dir_name = os.path.dirname(path)
     out = ""
     p = re.compile(
         r'<' + tag + r'\s+[^<>]*'
@@ -67,8 +67,25 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
             out += content[i:j]
             i = j
 
-            full = os.path.realpath(os.path.join(path, val))
-            if full.startswith(root):
+            full = ''
+            if dir_name.endswith('yaml'):
+                # content in yaml file
+                if val.startswith('../'):
+                    # targeting a static file or a chapter in a different round
+                    full = os.path.realpath(os.path.join(root, val[3:]))
+                elif not val.startswith('/'):
+                    # targeting a file under the same round
+                    # exercise YAML files use names according to the pattern roundkey_chapter_exercisekey.yaml
+                    parts = os.path.basename(path).split('_', 1)
+                    if len(parts) > 1:
+                        round_key = parts[0]
+                        full = os.path.realpath(os.path.join(root, round_key, val))
+            else:
+                # content in html file
+                # dir_name points to either _build/html or _build/html/<round>
+                full = os.path.realpath(os.path.join(dir_name, val))
+
+            if full.startswith(root): # NB: root ends with "_build/html"
                 my_path = full[len(root)+1:]
 
                 # Links to chapters.
@@ -79,27 +96,26 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
                         #j = m.start('val')
                         #out += append + content[i:j] + my_path.replace('\\','/')
                         #i = m.end('val')
-
                 # Other links.
                 elif static_host:
                     j = m.start('val')
                     out += content[i:j] + static_host + my_path.replace('\\','/')
                     i = m.end('val')
-            elif path.endswith('yaml') and yaml_append and val.startswith('../') \
-                    and not out.endswith(yaml_append):
-                # Sphinx sets URLs to local files as relative URLs that work in
-                # the local filesystem (e.g., ../_images/myimage.png).
-                # The A+ frontend converts the URLs correctly when they are in
-                # the chapter content. (The URL must be converted to an absolute
-                # URL that refers to the MOOC grader course static files.)
-                # However, the conversion does not work for URLs in exercise
-                # descriptions because unlike for chapters, the service URL of
-                # an exercise does not refer to the course static files.
-                # Therefore, we add the attribute data-aplus-path="/static/{course}"
-                # that A+ frontend uses to set the correct URL path.
-                # Unfortunately, we must hardcode the MOOC grader static URL
-                # (/static) here.
-                out += yaml_append
+
+                elif dir_name.endswith('yaml') and yaml_append and not out.endswith(yaml_append):
+                    # Sphinx sets URLs to local files as relative URLs that work in
+                    # the local filesystem (e.g., ../_images/myimage.png).
+                    # The A+ frontend converts the URLs correctly when they are in
+                    # the chapter content. (The URL must be converted to an absolute
+                    # URL that refers to the MOOC grader course static files.)
+                    # However, the conversion does not work for URLs in exercise
+                    # descriptions because unlike for chapters, the service URL of
+                    # an exercise does not refer to the course static files.
+                    # Therefore, we add the attribute data-aplus-path="/static/{course}"
+                    # that A+ frontend uses to set the correct URL path.
+                    # Unfortunately, we must hardcode the MOOC grader static URL
+                    # (/static) here.
+                    out += yaml_append
 
     out += content[i:]
     return out


### PR DESCRIPTION
Links from exercise descriptions to chapters were particularly
still broken.
Commit b66484156e443e68af200b2b35ac1db9ea612503
fixed links from exercise descriptions to static files, but it is
now slightly refactored with this change.