### PR TITLE
The content of the submit directive to exercise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ linking a YAML configuration file with the `config` option.
 Some settings may also be defined directly with the directive options.
 The directive will attach the exercise at this position in the content chapter.
 Its arguments define the exercise key and max points with the optional difficulty.
+The instructions can be written in the body of the submit directive. The body
+supports RST syntax. If the instructions field is also given in the config.yaml, the
+body of the submit directive will be prioritized.
 It accepts the following options:
 
 * `config`: path to the YAML configuration file
@@ -385,6 +388,8 @@ It accepts the following options:
 .. submit:: 2 A100
   :submissions: 100
   :config: exercises/hello_python/config.yaml
+  
+  This will be shown in aplus as the instructions.
 ```
 
 ### 4. External exercise (LTI)
@@ -400,6 +405,8 @@ There are two ways to define LTI exercise:
   In this case, all LTI options written in the submit directive will be ignored.
 * Writing LTI options in the submit directive. Remark that in this case the submit directive must
   not have the `config` option set.
+
+In LTI excercises, the instructions cannot be written in the body of the submit directive.
 
 ```
 .. submit:: 3 B50

--- a/aplus_nodes.py
+++ b/aplus_nodes.py
@@ -4,6 +4,7 @@ from docutils import nodes
 
 import lib.yaml_writer as yaml_writer
 import lib.html_tools as html_tools
+import lib.translations as translations
 
 
 class html(nodes.General, nodes.Element):
@@ -147,6 +148,20 @@ def depart_html(self, node):
         node._html = u"".join(self.body[(node._body_begin+1):-1])
     if hasattr(node, 'yaml_data'):
         recursive_fill(self.body, node.yaml_data, node)
+        if 'data-aplus-exercise' in node:
+            # If the body of the submit directive is used to define the exercise
+            # description in RST, store the exercise description in the HTML format
+            # into the exercise YAML configuration file.
+            # If the submit directive is used without a body, it contains
+            # a placeholder text node, in which case the instructions in YAML
+            # must not be modified.
+            has_body = not (len(node) > 0 and node[0].tagname == 'p' and len(node[0]) > 0 \
+                and node[0][0].astext() == translations.get(self.builder.env, 'submit_placeholder'))
+            if has_body:
+                # The instructions in the submit directive body have been
+                # compiled to HTML at this point.
+                # Drop the wrapper <div data-aplus-exercise> element.
+                node.yaml_data['instructions'] = ''.join(self.body[node._body_begin + 1:node._body_end - 1])
         if hasattr(node, 'yaml_write'):
             yaml_writer.write(node.yaml_write, node.pop_yaml())
     if node.no_write:


### PR DESCRIPTION
The exercise instructions can now be written in the submit directives body. Instructions are written in rst and support most of it's features.

I had to redo this due to unclear git history. 