### PR TITLE
Adding new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ The questionnaire directive accepts the following options:
   (select N questions randomly on each load)
 * `category`: exercise category
 * `status`: exercise status (default "unlisted"). See available [statuses](#list-of-exercise-statuses).
+* `allow-assistant-viewing`: Allows assistants to view the submissions of the students.
+  Can be set to true or false. Overrides any options set in the conf.py or config.yaml files.
+* `allow-assistant-grading`: Allows assistants to grade the submissions of the students.
+  Can be set to true or false. Overrides any options set in the conf.py or config.yaml files.
 
 The contents of the questionnaire directive define the questions and possible
 instructions to students.
@@ -362,6 +366,10 @@ It accepts the following options:
   to the exercise and the exercise JS may control the submission itself.
   See [the chapter content documentation](https://github.com/Aalto-LeTech/a-plus/blob/master/doc/CONTENT.md)
   (the HTML attribute `data-aplus-ajax`).
+* `allow-assistant-viewing`: Allows assistants to view the submissions of the students.
+  Can be set to true or false. Overrides any options set in the conf.py or config.yaml files.
+* `allow-assistant-grading`: Allows assistants to grade the submissions of the students.
+  Can be set to true or false. Overrides any options set in the conf.py or config.yaml files.
 * `quiz`: If set, the exercise feedback will take the place of the exercise instructions.
   This makes sense for questionnaires since their feedback contains the submission form.
   In RST, you would usually define questionnaires with the questionnaire directive,
@@ -388,7 +396,7 @@ It accepts the following options:
 .. submit:: 2 A100
   :submissions: 100
   :config: exercises/hello_python/config.yaml
-  
+
   This will be shown in aplus as the instructions.
 ```
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,16 @@ For example, `.. freetext:: 30 string-ignorews-ignorequotes`.
 The question directives may define instructions. After the instructions,
 the contents of the directive define the choices, the correct solution, and
 possible hints. The hints are targeted to specific choices and they are shown
-after answering. See the example below.
+after answering.
+
+The body of the `freetext` question is
+expected to be its model solution. However, the question instructions can be written
+inside the body before the model answer. The instructions and the model solution must
+be separated with an empty line.
+
+If the questionnaire has the `feedback` option set, `freetext`
+questions may not have a model solution and the body of the question is shown as the
+question instructions.
 
 ```
 .. questionnaire:: 1 A60
@@ -280,11 +289,15 @@ after answering. See the example below.
 
 ### 2. Feedback questionnaire
 
-A feedback questionnaire is basically just like a graded questionnaire, but with
-the `feedback` option it uses the feedback category and CSS class by default.
+A feedback questionnaire is almost like a graded questionnaire. When the `feedback` option is set,
+the questionnaire uses the feedback category and CSS class by default.
 The options `chapter-feedback`, `weekly-feedback`, `appendix-feedback`, and
 `course-feedback` use a different CSS class (with the same name as the option).
 If points are not specified, they are set to zero.
+The `feedback` option can be set only to the last questionnaire of the RST file.
+
+The freetext questions are not expected to have a model solution, in essence the
+body of the freetext question will be shown as the question instructions.
 
 The question directives `agree-item` and `agree-item-generate` create questions
 with a 1-5 Likert scale. They take a title as the only positional argument and

--- a/directives/abstract_exercise.py
+++ b/directives/abstract_exercise.py
@@ -1,5 +1,12 @@
 import itertools
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
+
+
+def choice_truefalse(argument):
+    """Choice of "true" or "false".
+    This is an option conversion function for the option_spec in directives.
+    """
+    return directives.choice(argument, ('true', 'false'))
 
 
 class AbstractExercise(Directive):
@@ -23,3 +30,12 @@ class AbstractExercise(Directive):
                 else:
                     difficulty = u''.join(chars)
         return difficulty, points
+
+    def set_assistant_permissions(self, data):
+        tobool = {'true': True, 'false': False}
+
+        if 'allow-assistant-grading' in self.options:
+            data['allow_assistant_grading'] = tobool[self.options['allow-assistant-grading']]
+
+        if 'allow-assistant-viewing' in self.options:
+            data['allow_assistant_viewing'] = tobool[self.options['allow-assistant-viewing']]

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -10,7 +10,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 import aplus_nodes
 import lib.translations as translations
 import lib.yaml_writer as yaml_writer
-from directives.abstract_exercise import AbstractExercise
+from directives.abstract_exercise import AbstractExercise, choice_truefalse
 
 
 class Questionnaire(AbstractExercise):
@@ -29,6 +29,8 @@ class Questionnaire(AbstractExercise):
         'title': directives.unchanged,
         'category': directives.unchanged,
         'status': directives.unchanged,
+        'allow-assistant-viewing': choice_truefalse,
+        'allow-assistant-grading': choice_truefalse,
     }
 
     def run(self):
@@ -110,6 +112,8 @@ class Questionnaire(AbstractExercise):
                 u'fields': (u'#!children', None),
             }],
         }
+        self.set_assistant_permissions(data)
+
         if not 'no-override' in self.options and category in override:
             data.update(override[category])
             if 'url' in data:

--- a/directives/submit.py
+++ b/directives/submit.py
@@ -12,7 +12,7 @@ import aplus_nodes
 import lib.translations as translations
 import lib.yaml_writer as yaml_writer
 from lib.yaml_writer import ensure_unicode
-from directives.abstract_exercise import AbstractExercise
+from directives.abstract_exercise import AbstractExercise, choice_truefalse
 
 
 class SubmitForm(AbstractExercise):
@@ -35,6 +35,8 @@ class SubmitForm(AbstractExercise):
         'radar_minimum_match_tokens': directives.unchanged,
         'category': directives.unchanged,
         'status': directives.unchanged,
+        'allow-assistant-viewing': choice_truefalse,
+        'allow-assistant-grading': choice_truefalse,
     }
 
     def run(self):
@@ -107,6 +109,7 @@ class SubmitForm(AbstractExercise):
             u'max_group_size': data.get('max_group_size', env.config.default_max_group_size),
             u'points_to_pass': self.options.get('points-to-pass', data.get('points_to_pass', 0)),
         })
+        self.set_assistant_permissions(data)
 
         if self.content:
             self.assert_has_content()


### PR DESCRIPTION
Options allow-assistant-grading and allow-assistant-viewing can now be set in the submit and questionnaire directives.
Other commit is about clarifying the README about the usage of freetext questions in the feedback and normal questionnaires.