### PR TITLE
Add useful directives from aplus-manual extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,75 @@ This extension must be activated separately in the project conf.py
   res0: Int = 14
 ```
 
-### 13. Media directives
+### 13. Submittable ACOS exercises
+
+The custom directive acos-submit behaves almost identically to the normal
+submit directive. It is intended for exercises that are hosted outside the MOOC grader,
+such as the ACOS server. The directive option url should define the URL path of
+the exercise in the ACOS server. The URL domain is added automatically based on
+the configuration value `acos_submit_base_url` in conf.py. The acos-submit
+directive also automatically uses the `ajax` flag of the submit directive.
+
+The usage:
+
+```
+In conf.py:
+  acos_submit_base_url = 'https://acos.cs.aalto.fi'
+  acos_submit_base_url = 'http://172.21.0.4:3000'
+
+In RST:
+.. acos-submit:: somekey 100
+  :title: My title
+  :url: /aplus/draganddrop/draganddrop-example/revealdemo
+```
+
+### 14. HTML div elements
+
+The div directive can be used to insert basic `<div>` html elements into the
+generated document. This is useful for styling and other similar reasons.
+
+Any arguments given to the directive will be added as classes to the resulting
+element.
+
+This extension is originally from
+https://github.com/dnnsoftware/Docs/blob/master/common/ext/div.py
+and is licensed under the MIT license (see source file comments for the
+license text).
+
+Usage example:
+
+```
+.. div:: css-class-1 css-class-2
+
+  Element contents (_parsed_ as **RST**). Note the blank line and the
+  indentation.
+```
+
+### 15. CSS styled topics
+
+Directive that inserts `topic` elements that are more friendly to css styling
+using the bootstrap framework. Usage:
+
+```
+.. styled-topic::
+  :class: css-class-1 css-class-2
+
+  Topic must include content. All content is **parsed** _normally_ as RST.
+
+  Note the blank line between the directive and its content, and the
+  indentation.
+```
+
+An optional `:class:` option can be used to insert other css classes to the
+resulting `<div>` element.
+
+This extension also registers a conf.py value of
+`'bootstrap_styled_topic_classes'`. It can be used to set default classes that are
+added to all styled-topic directives. The default value is `dl-horizontal topic`
+where `dl-horizontal` is useful for inserting bootstrap styled `<dl>` elements
+into the div.
+
+### 16. Media directives
 
 The media directives were developed basically for a single course and they
 may not be quite reusable for other usecases, but they are listed here anyway.

--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -14,6 +14,9 @@ from directives.ae_input import ActiveElementInput
 from directives.ae_output import ActiveElementOutput
 from directives.hiddenblock import HiddenBlock
 from directives.exercisecollection import ExerciseCollection
+from directives.div import DivDirective, DivNode
+from directives.bootstrap_styled_topic import StyledTopicDirective
+from directives.acos_submit import ACOSSubmitDirective
 
 def setup(app):
 
@@ -38,6 +41,8 @@ def setup(app):
     app.add_config_value('allow_assistant_viewing', True, 'html')
     app.add_config_value('allow_assistant_grading', False, 'html')
     app.add_config_value('course_head_urls', None, 'html')
+    app.add_config_value('bootstrap_styled_topic_classes', 'dl-horizontal topic', 'html')
+    app.add_config_value('acos_submit_base_url', 'http://172.21.0.2:3000', 'html')
 
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)
@@ -59,6 +64,8 @@ def setup(app):
         # with the builder output even though only the visitor functions should do that.
     )
 
+
+    app.add_node(DivNode, html=(DivNode.visit_div, DivNode.depart_div))
     # The directive for injecting document meta data.
     app.add_node(
         aplus_nodes.aplusmeta,
@@ -75,6 +82,9 @@ def setup(app):
     app.add_directive('agree-group',  AgreeGroup)
     app.add_directive('agree-item',  AgreeItem)
     app.add_directive('agree-item-generate', AgreeItemGenerate)
+    app.add_directive('div', DivDirective)
+    app.add_directive('styled-topic', StyledTopicDirective)
+    app.add_directive('acos-submit', ACOSSubmitDirective)
 
     # The submit directive.
     app.add_directive('submit', SubmitForm)

--- a/directives/acos_submit.py
+++ b/directives/acos_submit.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+acos-submit is a custom directive that behaves almost identically to the normal
+submit directive. It is intended for exercises that are hosted outside the MOOC grader,
+such as the ACOS server. The directive option url should define the URL path of
+the exercise in the ACOS server. The URL domain is added automatically based on
+the configuration value "acos_submit_base_url" (in conf.py). The acos-submit
+directive also automatically uses the "ajax" flag of the submit directive.
+"""
+from sphinx.errors import SphinxError
+from aplus_setup import SubmitForm
+
+class ACOSSubmitDirective(SubmitForm):
+    def run(self):
+        if 'config' in self.options:
+            raise SphinxError('Do not use the "config" option with ACOS exercises.')
+        if 'url' not in self.options:
+            raise SphinxError('The "url" option is mandatory. ' \
+                'It should only contain the URL path, not the domain, ' \
+                'since the domain is read from the configuration value "acos_submit_base_url".')
+
+        env = self.state.document.settings.env
+
+        # modify some options before calling this method in the super class
+        # ensure that the ajax option is set
+        self.options['ajax'] = None # flag is active even though it is None in the docutils API
+
+        # add the domain to the URL path
+        self.options['url'] = env.config.acos_submit_base_url + self.options['url']
+
+        return super().run()

--- a/directives/bootstrap_styled_topic.py
+++ b/directives/bootstrap_styled_topic.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+'''
+Directive that inserts "topic" elements that are more friendly to css styling
+using the bootstrap framework. Usage:
+
+.. styled-topic::
+  :class: css-class-1 css-class-2
+
+  Topic must include content. All content is **parsed** _normally_ as RST.
+
+  Note the blank line between the directive and its content, and the
+  indentation.
+
+An optional :class: option can be used to insert other css classes to the
+resulting <div> element.
+
+This extension also registers a conf.py value of
+'bootstrap_styled_topic_classes'. It can be used to set default classes that are
+added to all styled-topic directives. The default value is "dl-horizontal topic"
+where "dl-horizontal" is useful for inserting bootstrap styled <dl> elements
+into the div.
+'''
+from div import DivNode
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+
+class StyledTopicDirective(Directive):
+
+    optional_arguments = 0
+    option_spec = {'class': directives.class_option}
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        env = self.state.document.settings.env
+        text = '\n'.join(self.content)
+        node = DivNode(text)
+
+        node['classes'].extend(directives.class_option(env.config['bootstrap_styled_topic_classes']))
+        if 'class' in self.options:
+            node['classes'].extend(self.options['class'])
+
+        self.state.nested_parse(self.content, self.content_offset, node)
+
+        return [node]

--- a/directives/div.py
+++ b/directives/div.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+'''
+This directive can be used to insert basic <div> html elements into the
+generated document. This is useful for styling and other similar reasons.
+
+Any arguments given to the directive will be added as classes to the resulting
+element.
+
+This extension is originally from
+https://github.com/dnnsoftware/Docs/blob/master/common/ext/div.py
+and is licensed under the MIT license (see source file comments for the
+license text).
+
+Usage example:
+
+.. div:: css-class-1 css-class-2
+
+  Element contents (_parsed_ as **RST**). Note the blank line and the
+  indentation.
+'''
+import sys
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+
+
+# https://github.com/dnnsoftware/Docs/blob/master/common/ext/div.py
+
+# The MIT License (MIT)
+
+# Copyright (c) 2015 DNN Software
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+class DivNode(nodes.General, nodes.Element):
+
+    def __init__(self, text):
+        super(DivNode, self).__init__()
+
+    @staticmethod
+    def visit_div(self, node):
+        self.body.append(self.starttag(node, 'div'))
+
+    @staticmethod
+    def depart_div(self, node=None):
+        self.body.append('</div>\n')
+
+class DivDirective(Directive):
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {'name': directives.unchanged}
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        text = '\n'.join(self.content)
+        try:
+            if self.arguments:
+                classes = directives.class_option(self.arguments[0])
+            else:
+                classes = []
+        except ValueError:
+            raise self.error(
+                'Invalid class attribute value for "%s" directive: "%s".'
+                % (self.name, self.arguments[0]))
+        node = DivNode(text)
+        node['classes'].extend(classes)
+        self.add_name(node)
+        self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]


### PR DESCRIPTION
Added directives are: acos-submit, styled-topic and div. The usage of each directive is explained in the corresponding file in the directives folder.