### PR TITLE
Add two options to the POI directive for the presentation maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,10 @@ A point of interest is mostly like a normal admonition ("coloured info box"), bu
 they are also linked to each other with next/previous links. The links enable
 the user to quickly navigate between the points of interest.
 
+Point of interests may also be used to generate separate lecture slides
+(not directly included in the A+ content chapters). This requires a separate
+tool called "presentation maker".
+
 ```
 .. point-of-interest:: Title text
   :id: unique id, if not supplied a random id will be generated
@@ -550,6 +554,8 @@ the user to quickly navigate between the points of interest.
   :height: fixed height in pixels
   :columns: relative width of each column (e.g. for three columns 2 2 3)
   :bgimg: path to background image
+  :not_in_slides: a flag used with the presentation maker. This POI does not show in the slides if this is defined.
+  :not_in_book: If this flag is given, this POI does not appear in the A+ content chapter.
 
   Content of point-of-interest here.
 
@@ -558,6 +564,7 @@ the user to quickly navigate between the points of interest.
   ::newcol
 
   New column starts here. If :columns: option not present columns of equal width will be created.
+  (The presentation maker slides do not support the newcol feature.)
 ```
 
 

--- a/directives/point_of_interest.py
+++ b/directives/point_of_interest.py
@@ -11,6 +11,8 @@ Directive for creating "point of interest" summary block.
     :height: optional fixed height for content
     :bgimage: path to background image
     :columns: relative widths of poi content columns (e.e. 2 3 3)
+    :not_in_slides: used with the presentation maker. This POI does not show in the slides when used.
+    :not_in_book: This POI does not appear in the book material when used
 
     Content of point-of-interest here
 
@@ -49,6 +51,9 @@ class PointOfInterest(Directive):
         'height': directives.length_or_percentage_or_unitless,
         'columns': directives.unchanged,
         'bgimg':directives.uri,
+        # not_in_slides and not_in_book are used with the presentation maker
+        'not_in_slides': directives.flag,
+        'not_in_book': directives.flag,
     }
 
     def run(self):
@@ -79,6 +84,11 @@ class PointOfInterest(Directive):
 
         node = nodes.container()
         title = nodes.container()
+
+        if 'not_in_book' in self.options:
+            # Ignore this point of interest in the output since it shall not be
+            # included in the A+ course materials (e-book).
+            return []
 
         # add an extra div to force content to desired height
         hcontainer_opts = {
@@ -114,7 +124,6 @@ class PointOfInterest(Directive):
             cols = list(map(int,self.options['columns'].split()))
             allcols = sum(cols)
             colwidths = [x / allcols for x in cols]
-
 
         for batch in self.content:
             l += 1


### PR DESCRIPTION
These options are needed for the new presentation maker tool that generates lecture slides from the RST materials. The slide contents are taken from the point of interest directives.