### PR TITLE
Add settings to be defined in the index.rst or conf.py

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -43,7 +43,19 @@ def setup(app):
     app.add_config_value('course_head_urls', None, 'html')
     app.add_config_value('bootstrap_styled_topic_classes', 'dl-horizontal topic', 'html')
     app.add_config_value('acos_submit_base_url', 'http://172.21.0.2:3000', 'html')
-
+    app.add_config_value('numerate_ignoring_modules', None, 'html')
+    app.add_config_value('course_enrollment_start', None, 'html')
+    app.add_config_value('course_enrollment_end', None, 'html')
+    app.add_config_value('course_lifesupport_time', None, 'html')
+    app.add_config_value('course_archive_time', None, 'html')
+    app.add_config_value('course_enrollment_audience', None, 'html')
+    app.add_config_value('course_view_content_to', None, 'html')
+    app.add_config_value('course_index_mode', None, 'html')
+    app.add_config_value('course_content_numbering', None, 'html')
+    app.add_config_value('course_module_numbering', None, 'html')
+    app.add_config_value('course_description', None, 'html')
+    app.add_config_value('course_footer', None, 'html')
+    
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)
     app.connect('build-finished', toc_config.write)

--- a/directives/meta.py
+++ b/directives/meta.py
@@ -11,6 +11,7 @@ class AplusMeta(Directive):
     required_arguments = 0
     optional_arguments = 0
     option_spec = {
+    #module settings
         'open-time': directives.unchanged,
         'close-time': directives.unchanged,
         'late-time': directives.unchanged,
@@ -19,6 +20,24 @@ class AplusMeta(Directive):
         'hidden': directives.flag,
         'points-to-pass': directives.nonnegative_int, # set points to pass for modules
         'introduction': directives.unchanged, # module introduction HTML
+    #course settings
+        'course-start': directives.unchanged,
+        'course-close': directives.unchanged,
+        'enrollment-start': directives.unchanged,
+        'enrollment-end': directives.unchanged,
+        'lifesupport-time': directives.unchanged,
+        'archive-time': directives.unchanged,
+        'course-late': directives.unchanged,
+        'course-late-penalty': directives.unchanged,
+        'name': directives.unchanged,
+        'view-content-to': directives.unchanged,
+        'enrollment-audience': directives.unchanged,
+        'index-mode': directives.unchanged,
+        'content-numbering': directives.unchanged,
+        'module-numbering': directives.unchanged,
+        'course-description': directives.unchanged,
+        'course-footer': directives.unchanged,
+        'numerate-ignoring-modules': directives.unchanged,
     }
 
     def run(self):


### PR DESCRIPTION
These course-wide settings can be defined in main index.rst inside an aplusmeta directive. The values written there will be prioritized over those written in the conf.py. All settings doesn't need to be defined in the same place.