### PR TITLE
Bugfix: language is now read from the language postfix in multilingual courses

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -46,6 +46,9 @@ def setup(app):
 
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)
+    app.connect('source-read', toc_config.set_config_language_for_doc)
+    app.connect('doctree-resolved',
+        lambda app, doctree, docname: toc_config.set_config_language_for_doc(app, docname, None))
     app.connect('build-finished', toc_config.write)
 
     # Add node type that can describe HTML elements and store configurations.


### PR DESCRIPTION
Previously all index.yaml files used the same language, due to reading it from conf.py (even if all languages were set there, there was no method to choose right language for index_lang.yaml).
Trello issue: https://trello.com/c/F3iqx2wp/25-aplus-rst-tools-should-set-appenvconfiglanguage-appropriately-during-setup-so-that-translationspy-actually-does-its-job