### PR TITLE
Fix: in multilingual courses None titles in yaml files removed

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -40,6 +40,7 @@ def setup(app):
     app.add_config_value('skip_language_inconsistencies', False, 'html')
     app.add_config_value('allow_assistant_viewing', True, 'html')
     app.add_config_value('allow_assistant_grading', False, 'html')
+    app.add_config_value('enable_rst_file_language_detection', True, 'html')
     app.add_config_value('course_head_urls', None, 'html')
     app.add_config_value('bootstrap_styled_topic_classes', 'dl-horizontal topic', 'html')
     app.add_config_value('acos_submit_base_url', 'http://172.21.0.2:3000', 'html')

--- a/toc_config.py
+++ b/toc_config.py
@@ -24,6 +24,9 @@ def set_config_language_for_doc(app, docname, source):
     its parent directory (module01/en/chapter.rst). If the language can not
     be read from those sources, then config.language is not modified.
     '''
+    if not app.config.enable_rst_file_language_detection:
+        return
+
     filepath = app.env.doc2path(docname)
     folder = os.path.basename(os.path.dirname(filepath))
 


### PR DESCRIPTION
Previously if `title|i18n` was determined in config.yaml, build files often
contained None as title value as well. Now the key `title` is not written in the yaml if not defined in the RST file. Additionally if the `title|i18n` exists the handwritten titles in the RST are saved
into the `title|i18n` itself, so there can never be both `title|i18n` and `title` written in a yaml file.
If `env.conf.language` is not correct,
the manually written title is saved in under the wrong language, yet in the correct
yaml, so the written title doesn't override anything.

PR about defining `env.conf.language` #49 