### PR TITLE
Add an option to show the correct answer after the last submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The keys for the A+ course settings are listed below:
 :content-numbering: arabic
 :module-numbering: arabic
 :numerate-ignoring-modules: False
+:questionnaire-default-reveal-model-at-max-submissions: False
 ```
 
 Some fields require a value from specific choices (see also
@@ -228,6 +229,11 @@ even if the max points aren't defined in the argument. The questionnaire directi
   since the text fields are part of the pool from which the questions are randomly selected.)
 * `category`: exercise category
 * `status`: exercise status (default "unlisted"). See available [statuses](#list-of-exercise-statuses).
+* `reveal-model-at-max-submissions`: If true, the questionnaire feedback reveals
+  the model solution after the user has consumed all submission attempts.
+  The feedback may reveal the model solution even before the exercise deadline.
+  Note that A+ has a separate feature for showing exercise model solutions after
+  the deadline.
 * `allow-assistant-viewing`: Allows assistants to view the submissions of the students.
   Can be set to true or false. Overrides any options set in the conf.py or config.yaml files.
 * `allow-assistant-grading`: Allows assistants to grade the submissions of the students.

--- a/directives/abstract_exercise.py
+++ b/directives/abstract_exercise.py
@@ -1,12 +1,26 @@
 import itertools
+
 from docutils.parsers.rst import Directive, directives
+from sphinx.errors import SphinxError
 
 
 def choice_truefalse(argument):
     """Choice of "true" or "false".
     This is an option conversion function for the option_spec in directives.
     """
-    return directives.choice(argument, ('true', 'false'))
+    return directives.choice(argument, ('true', 'false', 'True', 'False'))
+
+def str_to_bool(string, error_msg_prefix=''):
+    booleans = {
+        'true': True,
+        'True': True,
+        'false': False,
+        'False': False,
+    }
+    try:
+        return booleans[string]
+    except KeyError:
+        raise SphinxError(error_msg_prefix + "{value} is not a boolean".format(value=string))
 
 
 class AbstractExercise(Directive):
@@ -32,10 +46,8 @@ class AbstractExercise(Directive):
         return difficulty, points
 
     def set_assistant_permissions(self, data):
-        tobool = {'true': True, 'false': False}
-
         if 'allow-assistant-grading' in self.options:
-            data['allow_assistant_grading'] = tobool[self.options['allow-assistant-grading']]
+            data['allow_assistant_grading'] = str_to_bool(self.options['allow-assistant-grading'])
 
         if 'allow-assistant-viewing' in self.options:
-            data['allow_assistant_viewing'] = tobool[self.options['allow-assistant-viewing']]
+            data['allow_assistant_viewing'] = str_to_bool(self.options['allow-assistant-viewing'])

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -13,7 +13,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 import aplus_nodes
 import lib.translations as translations
 import lib.yaml_writer as yaml_writer
-from directives.abstract_exercise import AbstractExercise, choice_truefalse
+from directives.abstract_exercise import AbstractExercise, choice_truefalse, str_to_bool
 
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ class Questionnaire(AbstractExercise):
         'title': directives.unchanged,
         'category': directives.unchanged,
         'status': directives.unchanged,
+        'reveal-model-at-max-submissions': choice_truefalse,
         'allow-assistant-viewing': choice_truefalse,
         'allow-assistant-grading': choice_truefalse,
     }
@@ -119,6 +120,17 @@ class Questionnaire(AbstractExercise):
                 u'fields': (u'#!children', None),
             }],
         }
+
+        meta_data = env.metadata[env.app.config.master_doc]
+        if 'reveal-model-at-max-submissions' in self.options:
+            data['reveal_model_at_max_submissions'] = str_to_bool(self.options['reveal-model-at-max-submissions'])
+        else:
+            default_reveal = str_to_bool(meta_data.get(
+                'questionnaire-default-reveal-model-at-max-submissions', 'false'),
+                error_msg_prefix=env.app.config.master_doc + " questionnaire-default-reveal-model-at-max-submissions: ")
+            if default_reveal:
+                data['reveal_model_at_max_submissions'] = default_reveal
+
         if env.aplus_pick_randomly_quiz:
             pick_randomly = self.options.get('pick_randomly', 0)
             if pick_randomly < 1:


### PR DESCRIPTION
Add `show_correct_answer` -option to questionnaires to show model solution. Previously the correct
answer was always shown after the last submission, but PR to change that is already in mooc-grader Aalto-LeTech/mooc-grader#48.