### PR TITLE
Fix collisions of the chapter keys in nested directories.

### DIFF
--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -122,6 +122,9 @@ class Questionnaire(AbstractExercise):
                 u'title': '',
                 u'fields': (u'#!children', None),
             }],
+            # The RST source file path is needed for fixing relative URLs
+            # in the exercise description.
+            '_rst_srcpath': env.doc2path(env.docname, None),
         }
 
         meta_data = env.metadata[env.app.config.master_doc]

--- a/directives/submit.py
+++ b/directives/submit.py
@@ -105,6 +105,9 @@ class SubmitForm(AbstractExercise):
             u'min_group_size': data.get('min_group_size', env.config.default_min_group_size),
             u'max_group_size': data.get('max_group_size', env.config.default_max_group_size),
             u'points_to_pass': self.options.get('points-to-pass', data.get('points_to_pass', 0)),
+            # The RST source file path is needed for fixing relative URLs
+            # in the exercise description.
+            '_rst_srcpath': env.doc2path(env.docname, None),
         })
         self.set_assistant_permissions(data)
 

--- a/lib/html_tools.py
+++ b/lib/html_tools.py
@@ -40,8 +40,16 @@ def rewrite_file_links(path, root, chapter_dirs, static_host):
             chapter_dirs,
             'data-aplus-chapter ',
             'data-aplus-path="/static/{course}" ',
+            yaml_data_dict.get('_rst_srcpath|i18n', yaml_data_dict.get('_rst_srcpath')),
         )
-        content = yaml.dump(yaml_data_dict, default_flow_style=False)
+        # _rst_srcpath is an internal value stored in the YAML file.
+        # It is the path of the RST source file that contains the exercise.
+        # The path is needed for fixing relative URLs, usually links pointing
+        # to other chapters and exercises. It may have multiple values for
+        # different languages in multilingual courses or only one string value
+        # in monolingual courses.
+        content = yaml.safe_dump(yaml_data_dict, default_flow_style=False,
+            allow_unicode=True)
     else:
         content = rewrite_links(
             content,
@@ -58,26 +66,31 @@ def rewrite_file_links(path, root, chapter_dirs, static_host):
 
 
 def rewrite_links(content, path, root, link_elements, other_elements,
-                    static_host, chapter_dirs, chapter_append, yaml_append):
+                    static_host, chapter_dirs, chapter_append, yaml_append,
+                    rst_src_path=None):
     q1 = re.compile(r'^(\w+:|#)')
     q2 = re.compile(r'^(' + '|'.join(chapter_dirs) + r')(/|\\)')
     for tag, attr in link_elements:
         content = rewrite_elements(content, tag, attr, path, root,
-                                    q1, static_host, q2, chapter_append, yaml_append)
+                                    q1, static_host, q2, chapter_append,
+                                    yaml_append, rst_src_path)
     for tag, attr in other_elements:
         content = rewrite_elements(content, tag, attr, path, root,
-                                    q1, static_host, None, None, yaml_append)
+                                    q1, static_host, None, None, yaml_append,
+                                    rst_src_path)
     return content
 
 
 def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append,
-                    yaml_append):
+                    yaml_append, rst_src_path=None):
     dir_name = os.path.dirname(path)
     out = ""
     p = re.compile(
         r'<' + tag + r'\s+[^<>]*'
         r'(?P<attr>' + attr + r')=(?P<slash>\\?)"(?P<val>[^"?#]*)'
     )
+    re_remove_lang = re.compile(r'_[a-z]{2}(\.html)?(#.+)?$')
+    # match strings ending with the language identifier: "_en", "_en.html", "_en#id", "_en.html#id"
     i = 0
     for m in p.finditer(content):
         val = m.group('val')
@@ -91,16 +104,19 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
             full = ''
             if path.endswith('.yaml'):
                 # content in yaml file
-                if val.startswith('../'):
-                    # targeting a static file or a chapter in a different round
-                    full = os.path.realpath(os.path.join(root, val[3:]))
-                elif not val.startswith('/'):
-                    # targeting a file under the same round
-                    # exercise YAML files use names according to the pattern roundkey_chapter_exercisekey.yaml
-                    parts = os.path.basename(path).split('_', 1)
-                    if len(parts) > 1:
-                        round_key = parts[0]
-                        full = os.path.realpath(os.path.join(root, round_key, val))
+                # rst_src_path: The RST source file path is needed for fixing
+                # relative URLs in the exercise description.
+                # It should have been saved in the YAML data by the exercise directive.
+                if rst_src_path:
+                    full = os.path.realpath(os.path.join(
+                        root,
+                        os.path.dirname(rst_src_path),
+                        val
+                    ))
+                else:
+                    # We don't know which directory the relative path starts from,
+                    # so just assume the build root. It is likely incorrect.
+                    full = os.path.realpath(os.path.join(root, val))
             else:
                 # content in html file
                 # dir_name points to either _build/html or _build/html/<round>
@@ -121,9 +137,9 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
                         # contains parts of the nested directory names in order
                         # to be unique within the module.
                         chapter_key = '_'.join(split_path[1:])
-                        # Remove language postfix (_en, _fi), if any.
-                        if chapter_key[-3] == '_':
-                            chapter_key = chapter_key[:-3]
+                        # Remove language postfix (_en, _fi), if any exist.
+                        # Preserve ".html" and "#id" if they exist.
+                        chapter_key = re_remove_lang.sub(r'\1\2', chapter_key, count=1)
                         modified_path = module_path + '/' + chapter_key
                         j = m.start('val')
                         out += append + content[i:j] + modified_path.replace('\\', '/')
@@ -135,7 +151,7 @@ def rewrite_elements(content, tag, attr, path, root, q1, static_host, q2, append
                     out += content[i:j] + static_host + my_path.replace('\\','/')
                     i = m.end('val')
 
-                elif dir_name.endswith('yaml') and yaml_append and not out.endswith(yaml_append):
+                elif path.endswith('.yaml') and yaml_append and not out.endswith(yaml_append):
                     # Sphinx sets URLs to local files as relative URLs that work in
                     # the local filesystem (e.g., ../_images/myimage.png).
                     # The A+ frontend converts the URLs correctly when they are in
@@ -175,27 +191,44 @@ def _write_file(file_path, content):
 
 
 def recursive_rewrite_links(data_dict, path, root, link_elements, other_elements,
-        static_host, chapter_dirs, chapter_append, yaml_append):
+        static_host, chapter_dirs, chapter_append, yaml_append, rst_src_path,
+        lang_key=False, lang=None):
     '''Rewrite links in the string values inside the data_dict.'''
     # YAML file may have a list or a dictionary in the topmost level.
+    # lang_key and lang are used to pick the correct language from rst_src_path.
     if isinstance(data_dict, dict):
         for key, val in data_dict.items():
+            if lang_key:
+                # data_dict is the value for a key that had the ending "|i18n",
+                # so now key is a language code.
+                lang = key
             if isinstance(val, dict) or isinstance(val, list):
                 recursive_rewrite_links(val, path, root, link_elements,
                     other_elements, static_host, chapter_dirs, chapter_append,
-                    yaml_append)
+                    yaml_append, rst_src_path, key.endswith('|i18n'), lang)
+                # lang_key: if key is, e.g., "title|i18n", then the val dict
+                # contains keys like "en" and "fi".
             elif isinstance(val, str):
+                if isinstance(rst_src_path, dict):
+                    lang_rst_src_path = rst_src_path.get(lang if lang else 'en')
+                else:
+                    lang_rst_src_path = rst_src_path
                 data_dict[key] = rewrite_links(val, path, root, link_elements,
                     other_elements, static_host, chapter_dirs, chapter_append,
-                    yaml_append)
+                    yaml_append, lang_rst_src_path)
 
     elif isinstance(data_dict, list):
         for i, a in enumerate(data_dict):
             if isinstance(a, dict) or isinstance(a, list):
                 recursive_rewrite_links(a, path, root, link_elements,
                     other_elements, static_host, chapter_dirs,
-                    chapter_append, yaml_append)
+                    chapter_append, yaml_append, rst_src_path, lang_key, lang)
             elif isinstance(a, str):
+                if isinstance(rst_src_path, dict):
+                    lang_rst_src_path = rst_src_path.get(lang if lang else 'en')
+                else:
+                    lang_rst_src_path = rst_src_path
                 data_dict[i] = rewrite_links(a, path, root, link_elements,
                     other_elements, static_host, chapter_dirs,
-                    chapter_append, yaml_append)
+                    chapter_append, yaml_append, lang_rst_src_path)
+

--- a/lib/toc_languages.py
+++ b/lib/toc_languages.py
@@ -28,6 +28,9 @@ IDENTICAL_EXERCISE_KEYS = [
     'category', 'max_points', 'difficulty', 'max_submissions',
     'min_group_size', 'max_group_size', 'points_to_pass', 'feedback',
 ]
+# Internal keys that may be joined in the |i18n format. Internal keys are only
+# used inside the a-plus-rst-tools to pass information forward.
+INTERNAL_KEYS_TO_JOIN = ['_rst_srcpath']
 
 
 def join(app, indexes):
@@ -152,6 +155,8 @@ class IndexJoiner:
                     c[k] = key + '.yaml'
                 elif k == 'children':
                     c[k] = self.join_children(c_path, lang1, v, lang2, c2.get(k, []))
+                elif k in INTERNAL_KEYS_TO_JOIN:
+                    c[k + '|i18n'] = join_values(lang1, v, lang2, c2.get(k, v))
                 elif deep_equals(v, c2.get(k, v)):
                     c[k] = v
                 else:

--- a/lib/toc_languages.py
+++ b/lib/toc_languages.py
@@ -283,8 +283,14 @@ def join_keys(lang1, key1, lang2, key2):
         if i < l2 and c == key2[i]:
             if not c in SEP or k == "" or k[-1] != c:
                 k += c
+    if not k or k in SEP:
+        raise SphinxError(
+            "Corresponding RST file names must match in multilingual courses:\n"
+            + key1 + "\n" + key2)
     if k[-1] in SEP:
         k = k[:-1]
+    if k[0] in SEP:
+        k = k[1:]
     return k
 
 

--- a/toc_config.py
+++ b/toc_config.py
@@ -202,7 +202,6 @@ def make_index(app, root, language=''):
                 u'unlisted' if hidden else u'ready'
             )
             chapter = {
-                u'key': name.split(u'/')[-1],#name.replace('/', '_'),
                 u'status': status,
                 u'name': first_title(child),
                 u'static_content': name + u'.html',
@@ -210,6 +209,14 @@ def make_index(app, root, language=''):
                 u'use_wide_column': app.config.use_wide_column,
                 u'children': [],
             }
+            # If the chapter RST file is in a nested directory under the module
+            # directory (e.g., module01/material/chapter.rst instead of
+            # module01/chapter.rst), then the chapter key must contain parts of
+            # the nested directory names in order to be unique within the module.
+            # Different directories could contain files with the same names.
+            key_parts = name.split('/')
+            chapter['key'] = '_'.join(key_parts[1:])
+
             if meta:
                 audience = meta.get('audience')
                 if audience:


### PR DESCRIPTION
This commit fixes the chapter keys in nested directories, so that they will
always be unique. The links to nested chapters need to be fixed as well. Update: This PR is about fixing those links, too.