### PR TITLE
Add postfixes to links so that sphinx finds the files

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -48,8 +48,10 @@ def setup(app):
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)
     app.connect('source-read', toc_config.set_config_language_for_doc)
-    app.connect('doctree-resolved',
-        lambda app, doctree, docname: toc_config.set_config_language_for_doc(app, docname, None))
+    app.connect('source-read', lambda app, docname, source:
+                toc_config.add_lang_postfixes_to_links(docname, source))
+    app.connect('doctree-resolved', lambda app, doctree, docname:
+                toc_config.set_config_language_for_doc(app, docname, None))
     app.connect('build-finished', toc_config.write)
 
     # Add node type that can describe HTML elements and store configurations.

--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -44,6 +44,7 @@ def setup(app):
     app.add_config_value('course_head_urls', None, 'html')
     app.add_config_value('bootstrap_styled_topic_classes', 'dl-horizontal topic', 'html')
     app.add_config_value('acos_submit_base_url', 'http://172.21.0.2:3000', 'html')
+    app.add_config_value('no_link_correction', None, 'html')
 
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)

--- a/toc_config.py
+++ b/toc_config.py
@@ -370,6 +370,26 @@ def traverse_tocs(app, doc):
     names = []
     for toc in doc.traverse(addnodes.toctree):
         hidden = toc.get('hidden', False)
-        for _,docname in toc.get('entries', []):
-            names.append((docname,hidden))
-    return [(name,hidden,app.env.get_doctree(name)) for name,hidden in names]
+        for _, docname in toc.get('entries', []):
+            names.append((docname, hidden))
+    return [(name, hidden, app.env.get_doctree(name)) for name, hidden in names]
+
+
+# This function adds the language postfix to chapterlinks in multilingual
+# courses, if it hasn't been manually added. This is necessary, since Sphinx
+# requires, that the file needs to exists, in order to make the link. However,
+# this post fix is removed in the rewrite_outdir function in html_tools, since
+# a-plus uses chapter keys in the url:s, and the postfixes are removed from
+# chapter keys when the language indexes are merged.
+def add_lang_postfixes_to_links(docname, source):
+    # The source argument is a list whose single element is the contents of the source file
+    postfix = docname[-3:]
+    if postfix[0] == '_':
+        # Links of the form :doc:`link text <path/file>` or `link text <path/file>`_
+        source[0] = re.sub(r"<([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)>",
+                            r"<\0\1\2" + postfix + ">",
+                            source[0])
+        # Links of the form :doc:`path/file`
+        source[0] = re.sub(r":doc:`([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)`",
+                            r":doc:`\0\1\2" + postfix + "`",
+                            source[0])

--- a/toc_config.py
+++ b/toc_config.py
@@ -391,8 +391,8 @@ def add_lang_postfixes_to_links(app, docname, source):
         postfix = docname[-3:]
         if postfix[0] == '_':
             # Links of the form :doc:`link text <path/file>` or `link text <path/file>`_
-            source[0] = re.sub(r"<([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)>",
-                                r"<\0\1\2" + postfix + ">",
+            source[0] = re.sub(r"<([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)>`([^_])",
+                                r"<\0\1\2" + postfix + r">`\3",
                                 source[0])
             # Links of the form :doc:`path/file`
             source[0] = re.sub(r":doc:`([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)`",

--- a/toc_config.py
+++ b/toc_config.py
@@ -381,15 +381,20 @@ def traverse_tocs(app, doc):
 # this post fix is removed in the rewrite_outdir function in html_tools, since
 # a-plus uses chapter keys in the url:s, and the postfixes are removed from
 # chapter keys when the language indexes are merged.
-def add_lang_postfixes_to_links(docname, source):
-    # The source argument is a list whose single element is the contents of the source file
-    postfix = docname[-3:]
-    if postfix[0] == '_':
-        # Links of the form :doc:`link text <path/file>` or `link text <path/file>`_
-        source[0] = re.sub(r"<([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)>",
-                            r"<\0\1\2" + postfix + ">",
-                            source[0])
-        # Links of the form :doc:`path/file`
-        source[0] = re.sub(r":doc:`([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)`",
-                            r":doc:`\0\1\2" + postfix + "`",
-                            source[0])
+# The source argument is a list whose single element is the contents of the source file
+def add_lang_postfixes_to_links(app, docname, source):
+    # If the course use different format in links or for some other reason links
+    # need to stay untouched, add no_link_correction to conf.py or
+    # no-link-correction to the main index
+    if ("no_link_correction" not in app.env.metadata[app.config.master_doc]
+            and not app.config.no_link_correction):
+        postfix = docname[-3:]
+        if postfix[0] == '_':
+            # Links of the form :doc:`link text <path/file>` or `link text <path/file>`_
+            source[0] = re.sub(r"<([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)>",
+                                r"<\0\1\2" + postfix + ">",
+                                source[0])
+            # Links of the form :doc:`path/file`
+            source[0] = re.sub(r":doc:`([a-zA-Z0-9_/.]+/)?([a-zA-Z0-9_]+[^_]..)`",
+                                r":doc:`\0\1\2" + postfix + "`",
+                                source[0])


### PR DESCRIPTION
Courses with language postfixes in their file names such as `first_round_en`
and `first_round_fi` can now leave the postfix from the link. Allthough the
postfix is added in the source read phase of the build, they must be removed
later, since a-plus uses combined chapterkeys.

The recommendable file structure in multilingual courses is to have corresponding
materials in the same folder, using identical names with postfixes. Some courses
use different ways of implementing the structure (for example traky), and this
change wont propably work with them all.